### PR TITLE
add circleci-config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2.1
+jobs:
+  build:
+    parameters:
+      dir:
+        type: string
+        default: ""
+    description: "build << parameters.container-image >>"
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Lint Dockerfile
+          command: |
+            dir=<< parameters.dir >>
+            if [ "$dir" = "" ]; then dir="." ; fi
+            docker run --rm -i hadolint/hadolint /bin/hadolint - < $dir/Dockerfile
+      - run:
+          name: Build images
+          command: |
+            if [ "$dir" = "" ]; then dir="." ; fi
+            dir=<< parameters.dir >>
+            docker build -t test:latest $dir
+workflows:
+  main:
+    jobs:
+      - build


### PR DESCRIPTION
Hi! I think it is good to use CircleCI to test Dockerfile.

So I added CircleCI config for DockerLint.
As current Dockerfile is not working, I tested this CircleCI config with the Dockerfile below.

```console
$ cat Dockerfile
FROM ubuntu:18.04

CMD ["sleep", "infinity"]
```

If you are ok to CI with CircleCI, you also need to setup your project to use CircleCI guided by [this link](https://circleci.com/docs/2.0/getting-started/#setting-up-your-build-on-circleci)